### PR TITLE
Ensure unauthenticated pages show navigation

### DIFF
--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -20,8 +20,8 @@
       '        <li class="nav-item"><a class="nav-link" href="blog.html" data-nav="blog">Blog</a></li>',
       '      </ul>',
       '      <div class="d-flex gap-2 ms-lg-3">',
-      '        <a class="btn btn-outline-primary" href="login.html">Log in</a>',
-      '        <a class="btn btn-primary" href="signup.html">Sign up</a>',
+      '        <a class="btn btn-outline-primary" href="login.html" data-nav="login">Log in</a>',
+      '        <a class="btn btn-primary" href="signup.html" data-nav="signup">Sign up</a>',
       "      </div>",
       "    </div>",
       "  </div>",
@@ -60,16 +60,24 @@
       return;
     }
 
-    const navPath = NAV_TYPES[navType] || NAV_TYPES.unauth;
+    const resolvedNavType = NAV_TYPES[navType] ? navType : "unauth";
+    const navPath = NAV_TYPES[resolvedNavType];
+    const fallbackMarkup = NAV_FALLBACKS[resolvedNavType] || "";
+
+    if (fallbackMarkup) {
+      renderNavigation(container, resolvedNavType, activeNavKey, fallbackMarkup);
+    }
+
+    if (!navPath) {
+      return;
+    }
 
     $.get(navPath)
       .done(function (markup) {
-        renderNavigation(container, navType, activeNavKey, markup);
+        renderNavigation(container, resolvedNavType, activeNavKey, markup);
       })
       .fail(function (jqXHR, textStatus) {
         console.error("Failed to load navigation component", textStatus);
-        const fallbackMarkup = NAV_FALLBACKS[navType] || NAV_FALLBACKS.unauth;
-        renderNavigation(container, navType, activeNavKey, fallbackMarkup);
       });
   }
 

--- a/components/unauth-nav.html
+++ b/components/unauth-nav.html
@@ -31,8 +31,8 @@
         </li>
       </ul>
       <div class="d-flex gap-2 ms-lg-3">
-        <a class="btn btn-outline-primary" href="login.html">Log in</a>
-        <a class="btn btn-primary" href="signup.html">Sign up</a>
+        <a class="btn btn-outline-primary" href="login.html" data-nav="login">Log in</a>
+        <a class="btn btn-primary" href="signup.html" data-nav="signup">Sign up</a>
       </div>
     </div>
   </div>

--- a/login.html
+++ b/login.html
@@ -14,6 +14,7 @@
     <script>
       window.pageConfig = {
         navType: "unauth",
+        activeNav: "login",
         redirectIfAuthenticated: "dashboard.html",
       };
     </script>

--- a/signup.html
+++ b/signup.html
@@ -14,6 +14,7 @@
     <script>
       window.pageConfig = {
         navType: "unauth",
+        activeNav: "signup",
         redirectIfAuthenticated: "dashboard.html",
       };
     </script>


### PR DESCRIPTION
## Summary
- ensure the unauthenticated navigation markup is rendered immediately using the fallback content
- add nav metadata so the login and signup buttons highlight correctly on their respective pages

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68d78621c1d083318e6b0045d095143a