### PR TITLE
Handle API expectations for auth flows

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -6,22 +6,69 @@
       .catch(() => ({}));
   }
 
+  function extractErrorMessage(data, fallbackMessage) {
+    if (!data) {
+      return fallbackMessage;
+    }
+
+    if (data.detail) {
+      if (typeof data.detail === "string") {
+        return data.detail;
+      }
+      if (Array.isArray(data.detail) && data.detail.length) {
+        return data.detail
+          .map((item) => {
+            if (!item) {
+              return null;
+            }
+            if (typeof item === "string") {
+              return item;
+            }
+            const parts = [];
+            if (Array.isArray(item.loc) && item.loc.length) {
+              parts.push(item.loc.join("."));
+            }
+            if (item.msg) {
+              parts.push(item.msg);
+            }
+            return parts.join(": ") || null;
+          })
+          .filter(Boolean)
+          .join(". ");
+      }
+    }
+
+    return data.message || data.error || fallbackMessage;
+  }
+
   function handleResponse(response) {
     if (!response.ok) {
       return parseJson(response).then((data) => {
-        const errorMessage = data.message || "Authentication failed";
+        const errorMessage = extractErrorMessage(data, "Authentication failed");
         throw new Error(errorMessage);
       });
     }
     return parseJson(response);
   }
 
-  function storeToken(token) {
-    if (!token) {
+  function storeToken(session) {
+    if (!session || !session.access_token) {
       throw new Error("Missing authentication token");
     }
+
+    const record = {
+      accessToken: session.access_token,
+      tokenType: session.token_type || "bearer",
+    };
+
     if (global.localStorage) {
-      global.localStorage.setItem("authToken", token);
+      try {
+        global.localStorage.setItem("authSession", JSON.stringify(record));
+      } catch (error) {
+        console.warn("Unable to persist auth session", error);
+      }
+      global.localStorage.setItem("authToken", record.accessToken);
+      global.localStorage.setItem("authTokenType", record.tokenType);
     }
   }
 
@@ -35,19 +82,24 @@
     $alert.addClass("d-none").text("");
   }
 
-  function submitForm({ url, payload, $form }) {
+  function submitForm({ url, payload, $form, buildRequest }) {
     clearError($form);
     const submitButton = $form.find("button[type='submit']");
     const originalText = submitButton.text();
     submitButton.prop("disabled", true).text("Loading...");
 
-    return fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
-    })
+    const requestInit =
+      typeof buildRequest === "function"
+        ? buildRequest(payload)
+        : {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          };
+
+    return fetch(url, requestInit)
       .then(handleResponse)
       .catch((error) => {
         displayError($form, error.message);
@@ -80,6 +132,7 @@
         username: $form.find("#signupUsername").val(),
         email: $form.find("#signupEmail").val(),
         password,
+        user_type: $form.find("#signupUserType").val(),
       };
 
       submitForm({
@@ -97,7 +150,7 @@
       event.preventDefault();
       const $form = $(this);
       const payload = {
-        email: $form.find("#loginEmail").val(),
+        username: $form.find("#loginUsername").val(),
         password: $form.find("#loginPassword").val(),
       };
 
@@ -105,9 +158,24 @@
         url: `${backendHost}/auth/login`,
         payload,
         $form,
+        buildRequest(data) {
+          const params = new URLSearchParams();
+          Object.keys(data).forEach((key) => {
+            if (data[key] !== undefined && data[key] !== null) {
+              params.append(key, data[key]);
+            }
+          });
+          return {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: params.toString(),
+          };
+        },
       })
         .then((data) => {
-          storeToken(data.token);
+          storeToken(data);
           global.location.href = "dashboard.html";
         })
         .catch(() => {});

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -112,18 +112,79 @@
     });
   }
 
+  function readStoredSession() {
+    if (!global.localStorage) {
+      return null;
+    }
+
+    var session = null;
+    var rawSession = global.localStorage.getItem("authSession");
+    if (rawSession) {
+      try {
+        session = JSON.parse(rawSession);
+      } catch (error) {
+        session = null;
+      }
+    }
+
+    if (!session) {
+      var legacyToken = global.localStorage.getItem("authToken");
+      if (legacyToken) {
+        session = {
+          accessToken: legacyToken,
+          tokenType: global.localStorage.getItem("authTokenType") || "bearer",
+        };
+      }
+    }
+
+    return session;
+  }
+
+  function clearStoredSession() {
+    if (!global.localStorage) {
+      return;
+    }
+    global.localStorage.removeItem("authSession");
+    global.localStorage.removeItem("authToken");
+    global.localStorage.removeItem("authTokenType");
+  }
+
   function attachAuthNavHandlers(container) {
     var signOutButton = container.querySelector("#signOutButton");
     if (!signOutButton) {
       return;
     }
 
+    var backendHost =
+      global.AppConfig && global.AppConfig.backendHost ? global.AppConfig.backendHost : null;
+
     signOutButton.addEventListener("click", function (event) {
       event.preventDefault();
-      if (global.localStorage) {
-        global.localStorage.removeItem("authToken");
+      var session = readStoredSession();
+      var request = null;
+
+      if (backendHost && session && session.accessToken) {
+        var headers = {
+          Authorization:
+            (session.tokenType ? session.tokenType : "Bearer") + " " + session.accessToken,
+        };
+
+        request = fetch(backendHost + "/auth/logout", {
+          method: "POST",
+          headers: headers,
+        }).catch(function (error) {
+          console.warn("Logout request failed", error);
+        });
       }
-      global.location.href = "login.html";
+
+      Promise.resolve(request)
+        .catch(function () {
+          /* swallow errors after logging */
+        })
+        .finally(function () {
+          clearStoredSession();
+          global.location.href = "index.html";
+        });
     });
   }
 

--- a/login.html
+++ b/login.html
@@ -30,8 +30,8 @@
             <div class="alert alert-danger form-alert d-none" role="alert"></div>
             <form id="loginForm" novalidate>
               <div class="mb-3">
-                <label for="loginEmail" class="form-label">Email address</label>
-                <input type="email" class="form-control" id="loginEmail" placeholder="you@example.com" required />
+                <label for="loginUsername" class="form-label">Email or username</label>
+                <input type="text" class="form-control" id="loginUsername" placeholder="you@example.com" required />
               </div>
               <div class="mb-4">
                 <label for="loginPassword" class="form-label">Password</label>

--- a/signup.html
+++ b/signup.html
@@ -37,6 +37,13 @@
                 <label for="signupEmail" class="form-label">Email address</label>
                 <input type="email" class="form-control" id="signupEmail" placeholder="you@example.com" required />
               </div>
+              <div class="mb-3">
+                <label for="signupUserType" class="form-label">Account type</label>
+                <select class="form-select" id="signupUserType" required>
+                  <option value="admin">Administrator</option>
+                  <option value="member">Member</option>
+                </select>
+              </div>
               <div class="row g-3">
                 <div class="col-md-6">
                   <label for="signupPassword" class="form-label">Password</label>


### PR DESCRIPTION
## Summary
- update the signup form to capture account type and display detailed API errors
- send login requests as form data, persist the returned token metadata, and surface backend validation errors
- call the backend logout endpoint before clearing local auth state and returning to the landing page

## Testing
- not run (static frontend project)


------
https://chatgpt.com/codex/tasks/task_e_68d8375898348331810454ef381d4f72